### PR TITLE
fix: jwt not getting expired, refactor auth middleware

### DIFF
--- a/controller/authentication.go
+++ b/controller/authentication.go
@@ -1,18 +1,22 @@
 package controller
 
 import (
-	"diary_api/helper"
 	"diary_api/model"
+	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 func Register(context *gin.Context) {
 	var input model.AuthenticationInput
 
 	if err := context.ShouldBindJSON(&input); err != nil {
-
+		fmt.Println(err)
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -23,13 +27,13 @@ func Register(context *gin.Context) {
 	}
 
 	savedUser, err := user.Save()
-
 	if err != nil {
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	context.JSON(http.StatusCreated, gin.H{"user": savedUser})
+	// Helper that creates and sends token when a user logins & signup
+	createSendToken(context, *savedUser, http.StatusCreated)
 }
 
 func Login(context *gin.Context) {
@@ -42,24 +46,48 @@ func Login(context *gin.Context) {
 	}
 
 	user, err := model.FindUserByUsername(input.Username)
-
 	if err != nil {
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
 	err = user.ValidatePassword(input.Password)
-
 	if err != nil {
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	jwt, err := helper.GenerateJWT(user)
+	// Helper that creates and sends token when a user logins & signup
+	createSendToken(context, user, http.StatusCreated)
+}
+
+// JWT helper functions are for auth modules only,
+// for better code readabilty / modularity, they should be in their scopes
+
+func createSendToken(c *gin.Context, user model.User, status int) {
+	jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
+	jwtExp, _ := strconv.Atoi(os.Getenv("TOKEN_TTL"))
+	// Evaluated in days, should be modified to fit your preferences
+	jwtDuration := time.Hour * 24 * time.Duration(jwtExp)
+	jwtMaxAge := time.Now().Add(jwtDuration).Unix()
+
+	jwt, err := generateJWT(user, jwtMaxAge, jwtSecret)
 	if err != nil {
-		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	context.JSON(http.StatusOK, gin.H{"jwt": jwt})
-} 
+	c.SetCookie("access_token", jwt, int(jwtDuration.Seconds()), "/", "localhost", false, true)
+
+	c.JSON(status, gin.H{"token": jwt, "user": user})
+}
+
+func generateJWT(user model.User, maxAge int64, secret []byte) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"id":  user.ID,
+		"iat": time.Now().Unix(),
+		// using "eat" doesn't actually expire the token
+		"exp": maxAge,
+	})
+	return token.SignedString(secret)
+}

--- a/controller/entry.go
+++ b/controller/entry.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"diary_api/helper"
 	"diary_api/model"
 	"net/http"
 
@@ -15,18 +14,21 @@ func AddEntry(context *gin.Context) {
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	// user, err := helper.CurrentUser(context)
+	// if err != nil {
+	// 	context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	// 	return
+	// }
 
-	user, err := helper.CurrentUser(context)
-
-	if err != nil {
-		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+	// user has been set in auth middleware
+	user, ok := context.MustGet("user").(*model.User)
+	if !ok {
+		context.JSON(http.StatusInternalServerError, gin.H{"error": "An error occured internally"})
 	}
 
 	input.UserID = user.ID
 
 	savedEntry, err := input.Save()
-
 	if err != nil {
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -36,12 +38,16 @@ func AddEntry(context *gin.Context) {
 }
 
 func GetAllEntries(context *gin.Context) {
+	// user, err := helper.CurrentUser(context)
+	// if err != nil {
+	// 	context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	// 	return
+	// }
 
-	user, err := helper.CurrentUser(context)
-
-	if err != nil {
-		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+	// user has been set in auth middleware
+	user, ok := context.MustGet("user").(*model.User)
+	if !ok {
+		context.JSON(http.StatusInternalServerError, gin.H{"error": "An error occured internally"})
 	}
 
 	context.JSON(http.StatusOK, gin.H{"data": user.Entries})

--- a/helper/jwt.go
+++ b/helper/jwt.go
@@ -1,54 +1,41 @@
 package helper
 
-import (
-	"diary_api/model"
-	"errors"
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v4"
-)
-
 // var privateKey = []byte(os.Getenv("JWT_PRIVATE_KEY"))
 
-func GenerateJWT(user model.User) (string, error) {
-	jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
-	tokenTTL, _ := strconv.Atoi(os.Getenv("TOKEN_TTL"))
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"id":  user.ID,
-		"iat": time.Now().Unix(),
-		// using "eat" doesn't actually expire the token
-		"exp": time.Now().Add(time.Second * time.Duration(tokenTTL)).Unix(),
-	})
-	return token.SignedString(jwtSecret)
-}
-
-func ValidateJWT(context *gin.Context) (*jwt.Token, error) {
-	reqToken := getTokenFromRequest(context)
-
-	token, err := jwt.Parse(reqToken, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-
-		jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
-
-		return jwtSecret, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	_, ok := token.Claims.(jwt.MapClaims)
-	if ok && token.Valid {
-		return token, nil
-	}
-	return nil, errors.New("invalid token provided")
-}
+// func GenerateJWT(user model.User) (string, error) {
+// 	jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
+// 	tokenTTL, _ := strconv.Atoi(os.Getenv("TOKEN_TTL"))
+// 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+// 		"id":  user.ID,
+// 		"iat": time.Now().Unix(),
+// 		// using "eat" doesn't actually expire the token
+// 		"exp": time.Now().Add(time.Second * time.Duration(tokenTTL)).Unix(),
+// 	})
+// 	return token.SignedString(jwtSecret)
+// }
+//
+// func ValidateJWT(context *gin.Context) (*jwt.Token, error) {
+// 	reqToken := getTokenFromRequest(context)
+//
+// 	token, err := jwt.Parse(reqToken, func(t *jwt.Token) (interface{}, error) {
+// 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+// 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+// 		}
+//
+// 		jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
+//
+// 		return jwtSecret, nil
+// 	})
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	_, ok := token.Claims.(jwt.MapClaims)
+// 	if ok && token.Valid {
+// 		return token, nil
+// 	}
+// 	return nil, errors.New("invalid token provided")
+// }
 
 // func CurrentUser(context *gin.Context) (model.User, error) {
 // 	err := ValidateJWT(context)
@@ -79,17 +66,17 @@ func ValidateJWT(context *gin.Context) (*jwt.Token, error) {
 // 	return token, err
 // }
 
-func getTokenFromRequest(context *gin.Context) string {
-	bearerToken := context.Request.Header.Get("Authorization")
-	splitToken := strings.Split(bearerToken, " ")
-	if len(splitToken) == 2 {
-		return splitToken[1]
-	}
-
-	// Get jwt from cookie if exist
-	ct, err := context.Cookie("access_token")
-	if err != nil {
-		return ct
-	}
-	return ""
-}
+// func getTokenFromRequest(context *gin.Context) string {
+// 	bearerToken := context.Request.Header.Get("Authorization")
+// 	splitToken := strings.Split(bearerToken, " ")
+// 	if len(splitToken) == 2 {
+// 		return splitToken[1]
+// 	}
+//
+// 	// Get jwt from cookie if exist
+// 	ct, err := context.Cookie("access_token")
+// 	if err != nil {
+// 		return ct
+// 	}
+// 	return ""
+// }

--- a/helper/jwt.go
+++ b/helper/jwt.go
@@ -13,69 +13,83 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-var privateKey = []byte(os.Getenv("JWT_PRIVATE_KEY"))
+// var privateKey = []byte(os.Getenv("JWT_PRIVATE_KEY"))
 
 func GenerateJWT(user model.User) (string, error) {
+	jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
 	tokenTTL, _ := strconv.Atoi(os.Getenv("TOKEN_TTL"))
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"id":  user.ID,
 		"iat": time.Now().Unix(),
-		"eat": time.Now().Add(time.Second * time.Duration(tokenTTL)).Unix(),
+		// using "eat" doesn't actually expire the token
+		"exp": time.Now().Add(time.Second * time.Duration(tokenTTL)).Unix(),
 	})
-	return token.SignedString(privateKey)
+	return token.SignedString(jwtSecret)
 }
 
-func ValidateJWT(context *gin.Context) error {
-	token, err := getToken(context)
+func ValidateJWT(context *gin.Context) (*jwt.Token, error) {
+	reqToken := getTokenFromRequest(context)
 
+	token, err := jwt.Parse(reqToken, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+
+		jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
+
+		return jwtSecret, nil
+	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	_, ok := token.Claims.(jwt.MapClaims)
-
 	if ok && token.Valid {
-		return nil
+		return token, nil
 	}
-
-	return errors.New("invalid token provided")
+	return nil, errors.New("invalid token provided")
 }
 
+// func CurrentUser(context *gin.Context) (model.User, error) {
+// 	err := ValidateJWT(context)
+// 	if err != nil {
+// 		return model.User{}, err
+// 	}
+//
+// 	token, _ := getToken(context)
+// 	claims, _ := token.Claims.(jwt.MapClaims)
+// 	userId := uint(claims["id"].(float64))
+//
+// 	user, err := model.FindUserById(userId)
+// 	if err != nil {
+// 		return model.User{}, err
+// 	}
+// 	return user, nil
+// }
 
-func CurrentUser(context *gin.Context) (model.User, error) {
-	err := ValidateJWT(context)
-	if err != nil {
-		return model.User{}, err
-	}
-
-	token, _ := getToken(context)
-	claims, _ := token.Claims.(jwt.MapClaims)
-	userId := uint(claims["id"].(float64))
-
-	user, err := model.FindUserById(userId)
-	if err != nil {
-		return model.User{}, err
-	}
-	return user, nil
-}
-
-func getToken(context *gin.Context) (*jwt.Token, error) {
-	tokenString := getTokenFromRequest(context)
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-
-		return privateKey, nil
-	})
-	return token, err
-}
+// func getToken(context *gin.Context) (*jwt.Token, error) {
+// 	tokenString := getTokenFromRequest(context)
+// 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+// 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+// 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+// 		}
+//
+// 		return privateKey, nil
+// 	})
+// 	return token, err
+// }
 
 func getTokenFromRequest(context *gin.Context) string {
 	bearerToken := context.Request.Header.Get("Authorization")
 	splitToken := strings.Split(bearerToken, " ")
 	if len(splitToken) == 2 {
 		return splitToken[1]
+	}
+
+	// Get jwt from cookie if exist
+	ct, err := context.Cookie("access_token")
+	if err != nil {
+		return ct
 	}
 	return ""
 }

--- a/middleware/jwtAuth.go
+++ b/middleware/jwtAuth.go
@@ -2,21 +2,38 @@ package middleware
 
 import (
 	"diary_api/helper"
+	"diary_api/model"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 func JWTAuthMiddleware() gin.HandlerFunc {
 	return func(context *gin.Context) {
-		err := helper.ValidateJWT(context)
+		token, err := helper.ValidateJWT(context)
 		if err != nil {
-			context.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 			fmt.Println(err)
+			context.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 			context.Abort()
 			return
 		}
+
+		claims, _ := token.Claims.(jwt.MapClaims)
+		userId := uint(claims["id"].(float64))
+
+		user, err := model.FindUserById(userId)
+		if err != nil {
+			fmt.Println(err)
+			context.JSON(http.StatusNotFound, gin.H{"error": err})
+			context.Abort()
+			return
+		}
+
+		// user can be accessed and modified if in other controllers if need be
+		context.Set("user", &user)
+
 		context.Next()
 	}
 }

--- a/middleware/jwtAuth.go
+++ b/middleware/jwtAuth.go
@@ -1,10 +1,12 @@
 package middleware
 
 import (
-	"diary_api/helper"
 	"diary_api/model"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
@@ -12,7 +14,7 @@ import (
 
 func JWTAuthMiddleware() gin.HandlerFunc {
 	return func(context *gin.Context) {
-		token, err := helper.ValidateJWT(context)
+		token, err := validateJWT(context)
 		if err != nil {
 			fmt.Println(err)
 			context.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
@@ -31,9 +33,52 @@ func JWTAuthMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// user can be accessed and modified if in other controllers if need be
+		// user can be accessed and modified in other controllers if need be
 		context.Set("user", &user)
 
 		context.Next()
 	}
+}
+
+// JWT helper functions are for auth modules only,
+// for better code readabilty / modularity, they should be in their scopes
+
+func validateJWT(c *gin.Context) (*jwt.Token, error) {
+	reqToken := getTokenFromRequest(c)
+
+	token, err := jwt.Parse(reqToken, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+
+		jwtSecret := []byte(os.Getenv("JWT_PRIVATE_KEY"))
+
+		return jwtSecret, nil
+	})
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+
+	_, ok := token.Claims.(jwt.MapClaims)
+	if ok && token.Valid {
+		return token, nil
+	}
+	return nil, errors.New("invalid token provided")
+}
+
+func getTokenFromRequest(c *gin.Context) string {
+	token := c.Request.Header.Get("Authorization")
+	ht := strings.Split(token, " ")
+	if len(ht) == 2 {
+		fmt.Println("hToken : ", ht[1])
+		return ht[1]
+	}
+
+	ct, err := c.Cookie("access_token")
+	if err != nil {
+		fmt.Println("cToken : ")
+		return ct
+	}
+	return ""
 }


### PR DESCRIPTION
1. Fixed jwt not expiring with "eat"
2. Save jwt as cookie after authentication
3. Refactored auth middleware to include user info by default, which is then accessible from other controllers. 